### PR TITLE
Update actions used in build

### DIFF
--- a/.github/workflows/docker.build.yaml
+++ b/.github/workflows/docker.build.yaml
@@ -78,7 +78,7 @@ jobs:
           echo "${{ steps.latest_php_82_version.outputs.value }}" > projects/beach/channels/beta/versions/beach-php-8_2.txt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           commit-message: Update PHP versions
           signoff: false


### PR DESCRIPTION
The changes in the releases updated to all are non-breaking.

Benefit is the use of Node v16, eliminating deprecation warnings.