### PR TITLE
Fix request for reviewers on the created PR

### DIFF
--- a/.github/workflows/docker.build.yaml
+++ b/.github/workflows/docker.build.yaml
@@ -95,4 +95,4 @@ jobs:
           labels: |
             automated pr
           team-reviewers: |
-            flownative/operations
+            operations


### PR DESCRIPTION
The organization dos not need to be given, this
should fix:

```
Requesting team reviewers 'flownative/operations'
Error: Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the flownative/versions.flownative.io repository.
```

The operations team *is* a collaborator, so I
assume the name does not match.